### PR TITLE
Origins: Implement changes up to v1.7.1

### DIFF
--- a/src/main/java/io/github/apace100/origins/command/OriginCommand.java
+++ b/src/main/java/io/github/apace100/origins/command/OriginCommand.java
@@ -1,29 +1,38 @@
 package io.github.apace100.origins.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.github.apace100.origins.Origins;
 import io.github.edwinmindcraft.origins.api.OriginsAPI;
 import io.github.edwinmindcraft.origins.api.capabilities.IOriginContainer;
 import io.github.edwinmindcraft.origins.api.origin.Origin;
 import io.github.edwinmindcraft.origins.api.origin.OriginLayer;
+import io.github.edwinmindcraft.origins.api.registry.OriginsBuiltinRegistries;
 import io.github.edwinmindcraft.origins.common.OriginsCommon;
 import io.github.edwinmindcraft.origins.common.network.S2COpenOriginScreen;
 import io.github.edwinmindcraft.origins.common.registry.OriginRegisters;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.core.Registry;
+import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.network.PacketDistributor;
 
-import java.util.Collection;
-import java.util.Objects;
+import java.util.*;
 
 import static net.minecraft.commands.Commands.argument;
 import static net.minecraft.commands.Commands.literal;
 
 public class OriginCommand {
+
+	private enum TargetType {
+		INVOKER,
+		SPECIFY
+	}
 
 	public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
 		dispatcher.register(
@@ -32,97 +41,74 @@ public class OriginCommand {
 								.then(argument("targets", EntityArgument.players())
 										.then(argument("layer", LayerArgumentType.layer())
 												.then(argument("origin", OriginArgumentType.origin())
-														.executes((command) -> {
-															// Sets the origins of several people in the given layer.
-															int i = 0;
-															Collection<ServerPlayer> targets = EntityArgument.getPlayers(command, "targets");
-															ResourceKey<OriginLayer> l = LayerArgumentType.getLayer(command, "layer");
-															ResourceKey<Origin> o = OriginArgumentType.getOrigin(command, "origin");
-															for (ServerPlayer target : targets) {
-																setOrigin(target, l, o);
-																i++;
-															}
-															if (targets.size() == 1)
-																command.getSource().sendSuccess(Component.translatable("commands.origin.set.success.single", targets.iterator().next().getDisplayName(), l.location(), o.location()), true);
-															else
-																command.getSource().sendSuccess(Component.translatable("commands.origin.set.success.multiple", targets.size(), l.location(), o.location()), true);
-															return i;
-														}))))
-						)
-						.then(literal("has")
+														.executes(OriginCommand::setOrigin))))
+						).then(literal("has")
 								.then(argument("targets", EntityArgument.players())
 										.then(argument("layer", LayerArgumentType.layer())
 												.then(argument("origin", OriginArgumentType.origin())
-														.executes((command) -> {
-															// Returns the number of people in the target selector with the origin in the given layer.
-															// Useful for checking if a player has the given origin in functions.
-															int i = 0;
-															Collection<ServerPlayer> targets = EntityArgument.getPlayers(command, "targets");
-															ResourceKey<OriginLayer> l = LayerArgumentType.getLayer(command, "layer");
-															ResourceKey<Origin> o = OriginArgumentType.getOrigin(command, "origin");
-															for (ServerPlayer target : targets) {
-																if (hasOrigin(target, l, o)) {
-																	i++;
-																}
-															}
-															if (i == 0) {
-																command.getSource().sendFailure(Component.translatable("commands.execute.conditional.fail"));
-															} else if (targets.size() == 1) {
-																command.getSource().sendSuccess(Component.translatable("commands.execute.conditional.pass"), false);
-															} else {
-																command.getSource().sendSuccess(Component.translatable("commands.execute.conditional.pass_count", i), false);
-															}
-															return i;
-														}))))
-						)
-						.then(literal("get")
+														.executes(OriginCommand::hasOrigin))))
+						).then(literal("get")
 								.then(argument("target", EntityArgument.player())
 										.then(argument("layer", LayerArgumentType.layer())
-												.executes((command) -> {
-													ServerPlayer target = EntityArgument.getPlayer(command, "target");
-													ResourceKey<OriginLayer> layer = LayerArgumentType.getLayer(command, "layer");
-													IOriginContainer.get(target).ifPresent(container -> {
-														ResourceKey<Origin> origin = container.getOrigin(layer);
-														command.getSource().sendSuccess(Component.translatable("commands.origin.get.result", target.getDisplayName(), layer.location(), origin.location(), origin.location()), false);
-													});
-													return 1;
-												})
+												.executes(OriginCommand::getOrigin)
 										)
 								)
 						).then(literal("gui")
+								.executes(command -> OriginCommand.openMultipleLayerScreens(command, TargetType.INVOKER))
 								.then(argument("targets", EntityArgument.players())
-										.executes((command) -> {
-											Collection<ServerPlayer> targets = EntityArgument.getPlayers(command, "targets");
-											targets.forEach(target -> IOriginContainer.get(target).ifPresent(container -> {
-												OriginsAPI.getActiveLayers().forEach(x -> container.setOrigin(x, OriginRegisters.EMPTY.getHolder().orElseThrow()));
-												container.synchronize();
-												container.checkAutoChoosingLayers(false);
-												OriginsCommon.CHANNEL.send(PacketDistributor.PLAYER.with(() -> target), new S2COpenOriginScreen(false));
-											}));
-											command.getSource().sendSuccess(Component.translatable("commands.origin.gui.all", targets.size()), false);
-											return targets.size();
-										})
+										.executes(command -> OriginCommand.openMultipleLayerScreens(command, TargetType.SPECIFY))
 										.then(argument("layer", LayerArgumentType.layer())
-												.executes((command) -> {
-													ResourceKey<OriginLayer> layer = LayerArgumentType.getLayer(command, "layer");
-													Collection<ServerPlayer> targets = EntityArgument.getPlayers(command, "targets");
-													Registry<OriginLayer> layersRegistry = OriginsAPI.getLayersRegistry();
-													targets.forEach(target -> IOriginContainer.get(target).ifPresent(container -> {
-														OriginLayer originLayer = layersRegistry.get(layer);
-														if (originLayer == null) return;
-														if (originLayer.enabled())
-															container.setOrigin(layer, Objects.requireNonNull(OriginRegisters.EMPTY.getKey()));
-														container.synchronize();
-														container.checkAutoChoosingLayers(false);
-														OriginsCommon.CHANNEL.send(PacketDistributor.PLAYER.with(() -> target), new S2COpenOriginScreen(false));
-													}));
-													command.getSource().sendSuccess(Component.translatable("commands.origin.gui.layer", targets.size(), layer.location()), false);
-													return targets.size();
-												})
+												.executes(OriginCommand::openSingleLayerScreen)
+										)
+								)
+						).then(literal("random")
+								.executes(command -> OriginCommand.randomizeOrigins(command, TargetType.INVOKER))
+								.then(argument("targets", EntityArgument.players())
+										.executes(command -> OriginCommand.randomizeOrigins(command, TargetType.SPECIFY))
+										.then(argument("layer", LayerArgumentType.layer())
+												.executes(OriginCommand::randomizeOrigin)
 										)
 								)
 						)
 		);
+	}
+
+	/**
+	 * 	Set the origin of the specified entities in the specified origin layer.
+	 * 	@param commandContext the command context
+	 * 	@return the number of players whose origin has been set
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is <b>not</b> an instance of {@link ServerPlayer}
+	 */
+	private static int setOrigin(CommandContext<CommandSourceStack> commandContext) throws CommandSyntaxException {
+		// Sets the origins of several people in the given layer.
+		Collection<ServerPlayer> targets = EntityArgument.getPlayers(commandContext, "targets");
+		ResourceKey<OriginLayer> originLayer = LayerArgumentType.getLayer(commandContext, "layer");
+		ResourceKey<Origin> origin = OriginArgumentType.getOrigin(commandContext, "origin");
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+
+		int processedTargets = 0;
+
+		Optional<Holder<OriginLayer>> layerHolder = OriginsAPI.getLayersRegistry().getHolder(originLayer);
+		Optional<Holder<Origin>> originHolder = OriginsAPI.getOriginsRegistry().getHolder(origin);
+
+		if (
+				layerHolder.isPresent() && layerHolder.get().isBound() && originHolder.isPresent() && originHolder.get().isBound() &&
+				(origin.equals(OriginRegisters.EMPTY.getKey()) || layerHolder.get().value().contains(origin.location()))
+		) {
+
+			for (ServerPlayer target : targets) {
+				setOrigin(target, originLayer, origin);
+				processedTargets++;
+			}
+
+
+			if (processedTargets == 1) serverCommandSource.sendSuccess(Component.translatable("commands.origin.set.success.single", targets.iterator().next().getDisplayName().getString(), layerHolder.get().value().name(), originHolder.get().value().getName()), true);
+			else serverCommandSource.sendSuccess(Component.translatable("commands.origin.set.success.multiple", processedTargets, layerHolder.get().value().name(), originHolder.get().value().getName()), true);
+		}
+
+		else serverCommandSource.sendFailure(Component.translatable("commands.origin.unregistered_in_layer", origin.location(), originLayer.location()));
+
+		return processedTargets;
 	}
 
 	private static void setOrigin(Player player, ResourceKey<OriginLayer> layer, ResourceKey<Origin> origin) {
@@ -134,7 +120,237 @@ public class OriginCommand {
 		);
 	}
 
+	/**
+	 * 	Check if the specified entities has the specified origin in the specified origin layer.
+	 * 	@param commandContext the command context
+	 * 	@return the number of players that has the specified origin in the specified origin layer
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is <b>not</b> an instance of {@link ServerPlayer}
+	 */
+	private static int hasOrigin(CommandContext<CommandSourceStack> commandContext) throws CommandSyntaxException {
+
+		Collection<ServerPlayer> targets = EntityArgument.getPlayers(commandContext, "targets");
+		ResourceKey<OriginLayer> originLayer = LayerArgumentType.getLayer(commandContext, "layer");
+		ResourceKey<Origin> origin = OriginArgumentType.getOrigin(commandContext, "origin");
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+
+		Optional<Holder<OriginLayer>> layerHolder = OriginsAPI.getLayersRegistry().getHolder(originLayer);
+		Optional<Holder<Origin>> originHolder = OriginsAPI.getOriginsRegistry().getHolder(origin);
+
+		int processedTargets = 0;
+
+		if (
+				layerHolder.isPresent() && layerHolder.get().isBound() && originHolder.isPresent() && originHolder.get().isBound() &&
+				(origin.equals(OriginRegisters.EMPTY.getKey()) || layerHolder.get().value().contains(origin))
+		) {
+			for (ServerPlayer target : targets) {
+				LazyOptional<IOriginContainer> originContainer = IOriginContainer.get(target);
+				if (originContainer.resolve().isPresent() && (origin.equals(OriginsBuiltinRegistries.ORIGINS.get().getResourceKey(Origin.EMPTY).get()) || originContainer.resolve().get().hasOrigin(originLayer)) && hasOrigin(target, originLayer, origin))
+					processedTargets++;
+			}
+
+			if (processedTargets == 0)
+				serverCommandSource.sendFailure(Component.translatable("commands.execute.conditional.fail"));
+			else if (processedTargets == 1)
+				serverCommandSource.sendSuccess(Component.translatable("commands.execute.conditional.pass"), true);
+			else
+				serverCommandSource.sendSuccess(Component.translatable("commands.execute.conditional.pass_count", processedTargets), true);
+		}
+		else serverCommandSource.sendFailure(Component.translatable("commands.origin.unregistered_in_layer", origin.location(), originLayer.location()));
+
+		return processedTargets;
+	}
+
 	private static boolean hasOrigin(Player player, ResourceKey<OriginLayer> layer, ResourceKey<Origin> origin) {
 		return IOriginContainer.get(player).map(x -> Objects.equals(x.getOrigin(layer), origin)).orElse(false);
+	}
+
+	/**
+	 * 	Get the origin of the specified entity from the specified origin layer.
+	 * 	@param commandContext the command context
+	 * 	@return 1
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is <b>not</b> an instance of {@link ServerPlayer}
+	 */
+	private static int getOrigin(CommandContext<CommandSourceStack> commandContext) throws CommandSyntaxException {
+
+		ServerPlayer target = EntityArgument.getPlayer(commandContext, "target");
+		ResourceKey<OriginLayer> originLayer = LayerArgumentType.getLayer(commandContext, "layer");
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+
+		Optional<Holder<OriginLayer>> layerHolder = OriginsAPI.getLayersRegistry().getHolder(originLayer);
+
+		IOriginContainer.get(target).ifPresent(container -> {
+			ResourceKey<Origin> origin = container.getOrigin(originLayer);
+			Optional<Holder<Origin>> originHolder = OriginsAPI.getOriginsRegistry().getHolder(origin);
+			serverCommandSource.sendSuccess(Component.translatable("commands.origin.get.result", target.getDisplayName().getString(), layerHolder.get().value().name(), originHolder.get().value().getName(), origin.location()), true);
+		});
+
+		return 1;
+
+	}
+
+	/**
+	 * 	Open the 'Choose Origin' screen for the specified origin layer to the specified entities.
+	 * 	@param commandContext the command context
+	 * 	@return the number of players that had the 'Choose Origin' screen opened for them
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is not an instance of {@link ServerPlayer}
+	 */
+	private static int openSingleLayerScreen(CommandContext<CommandSourceStack> commandContext) throws CommandSyntaxException {
+
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+		Collection<ServerPlayer> targets = EntityArgument.getPlayers(commandContext, "targets");
+		ResourceKey<OriginLayer> originLayer = LayerArgumentType.getLayer(commandContext, "layer");
+
+		OriginsAPI.getLayersRegistry().getHolder(originLayer).ifPresent(holder -> {
+
+			for (ServerPlayer target : targets) {
+				openLayerScreen(target, List.of(holder));
+			}
+
+			serverCommandSource.sendSuccess(Component.translatable("commands.origin.gui.layer", targets.size(), holder.value().name()), true);
+
+		});
+
+
+		return targets.size();
+
+	}
+
+
+	/**
+	 * 	Open the 'Choose Origin' screen for all the enabled origin layers to the specified entities.
+	 * 	@param commandContext the command context
+	 * 	@return the number of players that had the 'Choose Origin' screen opened for them
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is not an instance of {@link ServerPlayer}
+	 */
+	private static int openMultipleLayerScreens(CommandContext<CommandSourceStack> commandContext, TargetType targetType) throws CommandSyntaxException {
+
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+		List<ServerPlayer> targets = new ArrayList<>();
+		List<Holder<OriginLayer>> originLayers = OriginsAPI.getActiveLayers().stream().map(reference -> (Holder<OriginLayer>)reference).toList();
+
+		switch (targetType) {
+			case INVOKER -> targets.add(serverCommandSource.getPlayerOrException());
+			case SPECIFY -> targets.addAll(EntityArgument.getPlayers(commandContext, "targets"));
+		}
+
+		for (ServerPlayer target : targets) {
+			openLayerScreen(target, originLayers);
+		}
+
+		serverCommandSource.sendSuccess(Component.translatable("commands.origin.gui.all", targets.size()), false);
+		return targets.size();
+
+	}
+
+	/**
+	 * 	Randomize the origin of the specified entities in the specified origin layer.
+	 * 	@param commandContext the command context
+	 * 	@return the number of players that had their origin randomized in the specified origin layer
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is not an instance of {@link ServerPlayer}
+	 */
+	private static int randomizeOrigin(CommandContext<CommandSourceStack> commandContext) throws CommandSyntaxException {
+
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+		Collection<ServerPlayer> targets = EntityArgument.getPlayers(commandContext, "targets");
+		ResourceKey<OriginLayer> originLayer = LayerArgumentType.getLayer(commandContext, "layer");
+
+
+		Optional<Holder<OriginLayer>> layerHolder = OriginsAPI.getLayersRegistry().getHolder(originLayer);;
+
+		if (layerHolder.isPresent() && layerHolder.get().isBound()) {
+
+			if (layerHolder.get().value().allowRandom()) {
+				Holder<Origin> origin = null;
+				for (ServerPlayer target : targets) {
+					origin = getRandomOrigin(target, layerHolder.get());
+				}
+
+				if (targets.size() > 1) serverCommandSource.sendSuccess(Component.translatable("commands.origin.random.success.multiple", targets.size(), layerHolder.get().value().name()), true);
+				else if (targets.size() == 1) serverCommandSource.sendSuccess(Component.translatable("commands.origin.random.success.single", targets.iterator().next().getDisplayName().getString(), origin.value().getName(), layerHolder.get().value().name()), false);
+
+				return targets.size();
+			}
+			else {
+				serverCommandSource.sendFailure(Component.translatable("commands.origin.random.not_allowed", layerHolder.get().value().name()));
+				return 0;
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * 	Randomize the origins of the specified entities in all of the origin layers that allows to be randomized.
+	 * 	@param commandContext the command context
+	 * 	@return the number of players that had their origins randomized in all of the origin layers that allows to be randomized
+	 * 	@throws CommandSyntaxException if the entity is not found or if the entity is not an instance of {@link ServerPlayer}
+	 */
+	private static int randomizeOrigins(CommandContext<CommandSourceStack> commandContext, TargetType targetType) throws CommandSyntaxException {
+
+		CommandSourceStack serverCommandSource = commandContext.getSource();
+		List<ServerPlayer> targets = new ArrayList<>();
+		List<Holder.Reference<OriginLayer>> originLayers = OriginsAPI.getActiveLayers().stream().filter(originLayerReference -> originLayerReference.isBound() && originLayerReference.value().allowRandom()).toList();
+
+		switch (targetType) {
+			case INVOKER -> targets.add(serverCommandSource.getPlayerOrException());
+			case SPECIFY -> targets.addAll(EntityArgument.getPlayers(commandContext, "targets"));
+		}
+
+		for (ServerPlayer target : targets) {
+			for (Holder.Reference<OriginLayer> originLayer : originLayers) {
+				getRandomOrigin(target, originLayer);
+			}
+		}
+
+		serverCommandSource.sendSuccess(Component.translatable("commands.origin.random.all", targets.size(), originLayers.size()), false);
+		return targets.size();
+
+	}
+
+	private static void openLayerScreen(ServerPlayer target, List<Holder<OriginLayer>> originLayers) {
+
+		LazyOptional<IOriginContainer> originContainer = IOriginContainer.get(target);
+		originContainer.ifPresent(container -> {
+			for (Holder<OriginLayer> layer : originLayers) {
+				container.setOrigin(layer.unwrapKey().orElseThrow(), OriginRegisters.EMPTY.getKey());
+			}
+			container.synchronize();
+			container.checkAutoChoosingLayers(false);
+			OriginsCommon.CHANNEL.send(PacketDistributor.PLAYER.with(() -> target), new S2COpenOriginScreen(false));
+		});
+
+	}
+
+	private static Holder<Origin> getRandomOrigin(ServerPlayer target, Holder<OriginLayer> originLayer) {
+
+
+		List<Holder<Origin>> origins = originLayer.value().randomOrigins(target);
+		Holder<Origin> origin = origins.get(new Random().nextInt(origins.size()));
+		LazyOptional<IOriginContainer> originContainer = IOriginContainer.get(target);
+
+		originContainer.ifPresent(container -> {
+
+			boolean hadOriginBefore = container.hadAllOrigins();
+			boolean hadAllOrigins = container.hasAllOrigins();
+
+			container.setOrigin(originLayer, origin);
+			container.checkAutoChoosingLayers(false);
+			container.synchronize();
+
+			if (container.hasAllOrigins() && !hadAllOrigins) container.onChosen(hadOriginBefore);
+
+			if (origin.unwrapKey().isEmpty() || originLayer.unwrapKey().isEmpty()) return;
+
+			Origins.LOGGER.info(
+					"Player {} was randomly assigned the origin {} for layer {}",
+					target.getDisplayName().getString(),
+					origin.unwrapKey().get().location(),
+					originLayer.unwrapKey().get().location()
+			);
+
+		});
+
+		return origin;
+
 	}
 }

--- a/src/main/java/io/github/edwinmindcraft/origins/data/generator/OriginsPowerProvider.java
+++ b/src/main/java/io/github/edwinmindcraft/origins/data/generator/OriginsPowerProvider.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.github.apace100.apoli.util.AttributedEntityAttributeModifier;
 import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.apoli.util.modifier.ModifierUtil;
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.power.OriginsPowerTypes;
 import io.github.apace100.origins.registry.ModEnchantments;
@@ -28,7 +29,6 @@ import io.github.edwinmindcraft.apoli.common.registry.ApoliPowers;
 import io.github.edwinmindcraft.apoli.common.registry.action.ApoliDefaultActions;
 import io.github.edwinmindcraft.apoli.common.registry.action.ApoliEntityActions;
 import io.github.edwinmindcraft.apoli.common.registry.condition.*;
-import io.github.edwinmindcraft.apoli.common.util.ModifierUtils;
 import io.github.edwinmindcraft.origins.common.power.configuration.NoSlowdownConfiguration;
 import io.github.edwinmindcraft.origins.common.power.configuration.WaterVisionConfiguration;
 import io.github.edwinmindcraft.origins.data.tag.OriginsBlockTags;
@@ -69,7 +69,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		builder.put("underwater", Holder.direct(
 				ApoliPowers.MODIFY_BREAK_SPEED.get()
 						.configure(
-								new ModifyValueBlockConfiguration(ListConfiguration.of(ModifierUtils.fromAttributeModifier(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL))), allow),
+								new ModifyValueBlockConfiguration(ListConfiguration.of(ModifierUtil.fromAttributeModifier(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL))), allow),
 								PowerData.builder().addCondition(ApoliEntityConditions.and(
 										ApoliEntityConditions.SUBMERGED_IN.get().configure(new TagConfiguration<>(FluidTags.WATER)),
 										ApoliEntityConditions.ENCHANTMENT.get().configure(new EnchantmentConfiguration(new IntegerComparisonConfiguration(Comparison.EQUAL, 0), Enchantments.AQUA_AFFINITY, EnchantmentConfiguration.Calculation.SUM))
@@ -77,7 +77,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		builder.put("ungrounded", Holder.direct(
 				ApoliPowers.MODIFY_BREAK_SPEED.get()
 						.configure(
-								new ModifyValueBlockConfiguration(ListConfiguration.of(ModifierUtils.fromAttributeModifier(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL))), allow),
+								new ModifyValueBlockConfiguration(ListConfiguration.of(ModifierUtil.fromAttributeModifier(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL))), allow),
 								PowerData.builder().addCondition(ApoliEntityConditions.and(
 										ApoliEntityConditions.FLUID_HEIGHT.get().configure(new FluidTagComparisonConfiguration(new DoubleComparisonConfiguration(Comparison.GREATER_THAN, 0), FluidTags.WATER)),
 										ApoliEntityConditions.ON_BLOCK.get().configure(HolderConfiguration.defaultCondition(ApoliBuiltinRegistries.CONFIGURED_BLOCK_CONDITIONS), new ConditionData(true))
@@ -171,7 +171,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 	private void makeBlazebornPowers() {
 		PowerData hidden = PowerData.builder().hidden().build();
 		this.add("burning_wrath", ApoliPowers.MODIFY_DAMAGE_DEALT.get().configure(
-				new ModifyDamageDealtConfiguration(ModifierUtils.fromAttributeModifier(new AttributeModifier("Additional damage while on fire", 3, AttributeModifier.Operation.ADDITION))),
+				new ModifyDamageDealtConfiguration(ModifierUtil.fromAttributeModifier(new AttributeModifier("Additional damage while on fire", 3, AttributeModifier.Operation.ADDITION))),
 				PowerData.builder().addCondition(ApoliEntityConditions.ON_FIRE.get().configure(NoConfiguration.INSTANCE)).build()));
 		DamageSource waterDamage = new DamageSource("hurt_by_water").bypassArmor().bypassMagic();
 		this.add("damage_from_potions", ApoliPowers.ACTION_ON_ITEM_USE.get().configure(
@@ -183,7 +183,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		));
 		this.add("damage_from_snowballs", ApoliPowers.MODIFY_DAMAGE_TAKEN.get().configure(
 				new ModifyDamageTakenConfiguration(
-						ListConfiguration.of(ModifierUtils.fromAttributeModifier(new AttributeModifier("Snowball damage taken like Blazes", 3, AttributeModifier.Operation.ADDITION))),
+						ListConfiguration.of(ModifierUtil.fromAttributeModifier(new AttributeModifier("Snowball damage taken like Blazes", 3, AttributeModifier.Operation.ADDITION))),
 						Holder.direct(ApoliDamageConditions.PROJECTILE.get().configure(FieldConfiguration.of(Optional.of(EntityType.SNOWBALL)))),
 						ApoliDefaultConditions.BIENTITY_DEFAULT.getHolder().orElseThrow(),
 						ApoliDefaultActions.ENTITY_DEFAULT.getHolder().orElseThrow(),
@@ -227,7 +227,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		this.add("no_cobweb_slowdown", OriginsPowerTypes.NO_SLOWDOWN.get().configure(new NoSlowdownConfiguration(OriginsBlockTags.COBWEBS), hidden));
 		this.add("conduit_power_on_land", OriginsPowerTypes.CONDUIT_POWER_ON_LAND.get().configure(NoConfiguration.INSTANCE, hidden));
 
-		this.add("aerial_combatant", ApoliPowers.MODIFY_DAMAGE_DEALT.get().configure(new ModifyDamageDealtConfiguration(ModifierUtils.fromAttributeModifier(new AttributeModifier("Extra damage while fall flying", 1, AttributeModifier.Operation.MULTIPLY_BASE))), PowerData.builder().addCondition(ApoliEntityConditions.FALL_FLYING.get().configure(NoConfiguration.INSTANCE)).build()));
+		this.add("aerial_combatant", ApoliPowers.MODIFY_DAMAGE_DEALT.get().configure(new ModifyDamageDealtConfiguration(ModifierUtil.fromAttributeModifier(new AttributeModifier("Extra damage while fall flying", 1, AttributeModifier.Operation.MULTIPLY_BASE))), PowerData.builder().addCondition(ApoliEntityConditions.FALL_FLYING.get().configure(NoConfiguration.INSTANCE)).build()));
 		this.add("air_from_potions", ApoliPowers.ACTION_ON_ITEM_USE.get().configure(new ActionOnItemUseConfiguration(Holder.direct(ApoliItemConditions.INGREDIENT.get().configure(FieldConfiguration.of(Ingredient.of(Items.POTION)))), Holder.direct(ApoliEntityActions.GAIN_AIR.get().configure(FieldConfiguration.of(60))), ApoliDefaultActions.ITEM_DEFAULT.getHolder().orElseThrow(RuntimeException::new)), hidden));
 		this.add("aqua_affinity", ApoliPowers.MULTIPLE.get().configure(new MultipleConfiguration<>(makeAquaAffinity()), PowerData.DEFAULT));
 		this.add("aquatic", ApoliPowers.ENTITY_GROUP.get().configure(FieldConfiguration.of(MobType.WATER), hidden));

--- a/src/main/java/io/github/edwinmindcraft/origins/data/generator/OriginsPowerProvider.java
+++ b/src/main/java/io/github/edwinmindcraft/origins/data/generator/OriginsPowerProvider.java
@@ -30,6 +30,7 @@ import io.github.edwinmindcraft.apoli.common.registry.ApoliPowers;
 import io.github.edwinmindcraft.apoli.common.registry.action.ApoliDefaultActions;
 import io.github.edwinmindcraft.apoli.common.registry.action.ApoliEntityActions;
 import io.github.edwinmindcraft.apoli.common.registry.condition.*;
+import io.github.edwinmindcraft.apoli.common.util.ModifierUtils;
 import io.github.edwinmindcraft.origins.common.power.configuration.NoSlowdownConfiguration;
 import io.github.edwinmindcraft.origins.common.power.configuration.WaterVisionConfiguration;
 import io.github.edwinmindcraft.origins.data.tag.OriginsBlockTags;
@@ -71,7 +72,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		builder.put("underwater", Holder.direct(
 				ApoliPowers.MODIFY_BREAK_SPEED.get()
 						.configure(
-								new ModifyValueBlockConfiguration(ListConfiguration.of(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL)), allow),
+								new ModifyValueBlockConfiguration(ListConfiguration.of(ModifierUtils.fromAttributeModifier(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL))), allow),
 								PowerData.builder().addCondition(ApoliEntityConditions.and(
 										ApoliEntityConditions.SUBMERGED_IN.get().configure(new TagConfiguration<>(FluidTags.WATER)),
 										ApoliEntityConditions.ENCHANTMENT.get().configure(new EnchantmentConfiguration(new IntegerComparisonConfiguration(Comparison.EQUAL, 0), Enchantments.AQUA_AFFINITY, EnchantmentConfiguration.Calculation.SUM))
@@ -79,7 +80,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		builder.put("ungrounded", Holder.direct(
 				ApoliPowers.MODIFY_BREAK_SPEED.get()
 						.configure(
-								new ModifyValueBlockConfiguration(ListConfiguration.of(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL)), allow),
+								new ModifyValueBlockConfiguration(ListConfiguration.of(ModifierUtils.fromAttributeModifier(new AttributeModifier(UUID.randomUUID(), "Unnamed attribute modifier", 4, AttributeModifier.Operation.MULTIPLY_TOTAL))), allow),
 								PowerData.builder().addCondition(ApoliEntityConditions.and(
 										ApoliEntityConditions.FLUID_HEIGHT.get().configure(new FluidTagComparisonConfiguration(new DoubleComparisonConfiguration(Comparison.GREATER_THAN, 0), FluidTags.WATER)),
 										ApoliEntityConditions.ON_BLOCK.get().configure(HolderConfiguration.defaultCondition(ApoliBuiltinRegistries.CONFIGURED_BLOCK_CONDITIONS), new ConditionData(true))
@@ -157,7 +158,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 						ApoliEntityActions.GIVE.get().configure(new GiveConfiguration(new ItemStack(Items.EGG, 1))),
 						ApoliEntityActions.PLAY_SOUND.get().configure(new PlaySoundConfiguration(SoundEvents.CHICKEN_EGG, 1.0F, 1.0F))
 				), null), PowerData.DEFAULT));
-		this.add("slow_falling", ApoliPowers.MODIFY_FALLING.get().configure(new ModifyFallingConfiguration(0.01, false),
+		this.add("slow_falling", ApoliPowers.MODIFY_FALLING.get().configure(new ModifyFallingConfiguration(Optional.of(0.01), false, ListConfiguration.of()),
 				PowerData.builder().addCondition(ApoliEntityConditions.or(
 						ApoliEntityConditions.and(ApoliEntityConditions.SNEAKING.get().configure(NoConfiguration.INSTANCE), ApoliEntityConditions.FALL_FLYING.get().configure(NoConfiguration.INSTANCE)),
 						ApoliEntityConditions.and(ApoliEntityConditions.SNEAKING.get().configure(NoConfiguration.INSTANCE, new ConditionData(true)), ApoliEntityConditions.FALL_FLYING.get().configure(NoConfiguration.INSTANCE, new ConditionData(true)))
@@ -173,7 +174,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 	private void makeBlazebornPowers() {
 		PowerData hidden = PowerData.builder().hidden().build();
 		this.add("burning_wrath", ApoliPowers.MODIFY_DAMAGE_DEALT.get().configure(
-				new ModifyDamageDealtConfiguration(new AttributeModifier("Additional damage while on fire", 3, AttributeModifier.Operation.ADDITION)),
+				new ModifyDamageDealtConfiguration(ModifierUtils.fromAttributeModifier(new AttributeModifier("Additional damage while on fire", 3, AttributeModifier.Operation.ADDITION))),
 				PowerData.builder().addCondition(ApoliEntityConditions.ON_FIRE.get().configure(NoConfiguration.INSTANCE)).build()));
 		DamageSource waterDamage = new DamageSource("hurt_by_water").bypassArmor().bypassMagic();
 		this.add("damage_from_potions", ApoliPowers.ACTION_ON_ITEM_USE.get().configure(
@@ -185,12 +186,14 @@ public class OriginsPowerProvider extends PowerGenerator {
 		));
 		this.add("damage_from_snowballs", ApoliPowers.MODIFY_DAMAGE_TAKEN.get().configure(
 				new ModifyDamageTakenConfiguration(
-						ListConfiguration.of(new AttributeModifier("Snowball damage taken like Blazes", 3, AttributeModifier.Operation.ADDITION)),
+						ListConfiguration.of(ModifierUtils.fromAttributeModifier(new AttributeModifier("Snowball damage taken like Blazes", 3, AttributeModifier.Operation.ADDITION))),
 						Holder.direct(ApoliDamageConditions.PROJECTILE.get().configure(FieldConfiguration.of(Optional.of(EntityType.SNOWBALL)))),
 						ApoliDefaultConditions.BIENTITY_DEFAULT.getHolder().orElseThrow(),
 						ApoliDefaultActions.ENTITY_DEFAULT.getHolder().orElseThrow(),
 						ApoliDefaultActions.ENTITY_DEFAULT.getHolder().orElseThrow(),
-						ApoliDefaultActions.BIENTITY_DEFAULT.getHolder().orElseThrow()
+						ApoliDefaultActions.BIENTITY_DEFAULT.getHolder().orElseThrow(),
+						ApoliDefaultConditions.ENTITY_DEFAULT.getHolder().orElseThrow(),
+						ApoliDefaultConditions.ENTITY_DEFAULT.getHolder().orElseThrow()
 				), hidden
 		));
 		this.add("fire_immunity", ApoliPowers.INVULNERABILITY.get().configure(HolderConfiguration.of(Holder.direct(ApoliDamageConditions.FIRE.get().configure(NoConfiguration.INSTANCE))), PowerData.DEFAULT));
@@ -227,7 +230,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		this.add("no_cobweb_slowdown", OriginsPowerTypes.NO_SLOWDOWN.get().configure(new NoSlowdownConfiguration(OriginsBlockTags.COBWEBS), hidden));
 		this.add("conduit_power_on_land", OriginsPowerTypes.CONDUIT_POWER_ON_LAND.get().configure(NoConfiguration.INSTANCE, hidden));
 
-		this.add("aerial_combatant", ApoliPowers.MODIFY_DAMAGE_DEALT.get().configure(new ModifyDamageDealtConfiguration(new AttributeModifier("Extra damage while fall flying", 1, AttributeModifier.Operation.MULTIPLY_BASE)), PowerData.builder().addCondition(ApoliEntityConditions.FALL_FLYING.get().configure(NoConfiguration.INSTANCE)).build()));
+		this.add("aerial_combatant", ApoliPowers.MODIFY_DAMAGE_DEALT.get().configure(new ModifyDamageDealtConfiguration(ModifierUtils.fromAttributeModifier(new AttributeModifier("Extra damage while fall flying", 1, AttributeModifier.Operation.MULTIPLY_BASE))), PowerData.builder().addCondition(ApoliEntityConditions.FALL_FLYING.get().configure(NoConfiguration.INSTANCE)).build()));
 		this.add("air_from_potions", ApoliPowers.ACTION_ON_ITEM_USE.get().configure(new ActionOnItemUseConfiguration(Holder.direct(ApoliItemConditions.INGREDIENT.get().configure(FieldConfiguration.of(Ingredient.of(Items.POTION)))), Holder.direct(ApoliEntityActions.GAIN_AIR.get().configure(FieldConfiguration.of(60))), ApoliDefaultActions.ITEM_DEFAULT.getHolder().orElseThrow(RuntimeException::new)), hidden));
 		this.add("aqua_affinity", ApoliPowers.MULTIPLE.get().configure(new MultipleConfiguration<>(makeAquaAffinity()), PowerData.DEFAULT));
 		this.add("aquatic", ApoliPowers.ENTITY_GROUP.get().configure(FieldConfiguration.of(MobType.WATER), hidden));

--- a/src/main/java/io/github/edwinmindcraft/origins/data/generator/OriginsPowerProvider.java
+++ b/src/main/java/io/github/edwinmindcraft/origins/data/generator/OriginsPowerProvider.java
@@ -6,7 +6,6 @@ import io.github.apace100.apoli.util.AttributedEntityAttributeModifier;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.power.OriginsPowerTypes;
-import io.github.apace100.origins.registry.ModDamageSources;
 import io.github.apace100.origins.registry.ModEnchantments;
 import io.github.edwinmindcraft.apoli.api.configuration.*;
 import io.github.edwinmindcraft.apoli.api.generator.PowerGenerator;
@@ -14,7 +13,6 @@ import io.github.edwinmindcraft.apoli.api.power.ConditionData;
 import io.github.edwinmindcraft.apoli.api.power.IActivePower;
 import io.github.edwinmindcraft.apoli.api.power.PowerData;
 import io.github.edwinmindcraft.apoli.api.power.configuration.ConfiguredBlockCondition;
-import io.github.edwinmindcraft.apoli.api.power.configuration.ConfiguredEntityCondition;
 import io.github.edwinmindcraft.apoli.api.power.configuration.ConfiguredItemCondition;
 import io.github.edwinmindcraft.apoli.api.power.configuration.ConfiguredPower;
 import io.github.edwinmindcraft.apoli.api.power.configuration.power.TogglePowerConfiguration;
@@ -41,7 +39,6 @@ import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.FluidTags;
-import net.minecraft.tags.TagKey;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -198,7 +195,7 @@ public class OriginsPowerProvider extends PowerGenerator {
 		));
 		this.add("fire_immunity", ApoliPowers.INVULNERABILITY.get().configure(HolderConfiguration.of(Holder.direct(ApoliDamageConditions.FIRE.get().configure(NoConfiguration.INSTANCE))), PowerData.DEFAULT));
 		this.add("flame_particles", ApoliPowers.PARTICLE.get().configure(new ParticleConfiguration(ParticleTypes.FLAME, 4, false), hidden));
-		this.add("hotblooded", ApoliPowers.EFFECT_IMMUNITY.get().configure(ListConfiguration.of(MobEffects.POISON, MobEffects.HUNGER), PowerData.DEFAULT));
+		this.add("hotblooded", ApoliPowers.EFFECT_IMMUNITY.get().configure(new EffectImmunityConfiguration(ListConfiguration.of(MobEffects.POISON, MobEffects.HUNGER), false), PowerData.DEFAULT));
 		this.add("nether_spawn", ApoliPowers.MODIFY_PLAYER_SPAWN.get().configure(new ModifyPlayerSpawnConfiguration(Level.NETHER, 0.125F, null, "center", null, null), PowerData.DEFAULT));
 		this.add("water_vulnerability", ApoliPowers.DAMAGE_OVER_TIME.get().configure(
 				new DamageOverTimeConfiguration(20, 1, 1, 2, waterDamage, ModEnchantments.WATER_PROTECTION.get(), 1.0F),

--- a/src/main/resources/assets/origins/lang/en_us.json
+++ b/src/main/resources/assets/origins/lang/en_us.json
@@ -220,8 +220,8 @@
   "origin.origins.random.description": "You'll be assigned one of the following:",
 
   "layer.origins.origin.name": "Origin",
-  "layer.origins.origin.missing_origin.name": "Missing",
-  "layer.origins.origin.missing_origin.description": "You do not have an Origin.",
+  "origin.origins.empty.name": "Missing",
+  "origin.origins.empty.description": "You do not have an Origin.",
 
   "death.attack.no_water_for_gills": "%1$s didn't manage to keep wet",
   "death.attack.no_water_for_gills.player": "%1$s didn't manage to keep wet because they were fighting %2$s",

--- a/src/main/resources/assets/origins/lang/en_us.json
+++ b/src/main/resources/assets/origins/lang/en_us.json
@@ -231,11 +231,17 @@
   "death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
 
   "commands.origin.origin_not_found": "Unknown origin: %s",
-  "commands.origin.set.success.single": "Set origin of %s in layer %s to %s.",
-  "commands.origin.set.success.multiple": "Set origin of %s targets in layer %s to %s.",
+  "commands.origin.layer_not_found": "Unknown layer: %s",
+  "commands.origin.unregistered_in_layer": "Origin %1$s is not registered in layer %2$s!",
   "commands.origin.get.result": "%s has the following %s: %s (%s)",
-  "commands.origin.gui.all": "Opened the selection GUI for %s players.",
-  "commands.origin.gui.layer": "Opened the \"%2$s\" selection GUI for %1$s players.",
+  "commands.origin.gui.all": "Opened the selection GUI for %s players",
+  "commands.origin.gui.layer": "Opened the \"%2$s\" selection GUI for %1$s players",
+  "commands.origin.random.all": "Randomly assigned an origin to %1$s targets in %2$s layers",
+  "commands.origin.random.not_allowed": "The layer %1$s does not allow for random origins!",
+  "commands.origin.random.success.multiple": "Randomly assigned an origin to %1$s targets in layer %2$s",
+  "commands.origin.random.success.single": "Randomly assigned the origin %2$s to %1$s in layer %3$s",
+  "commands.origin.set.success.multiple": "Set origin of %s targets in layer %s to %s",
+  "commands.origin.set.success.single": "Set origin of %s in layer %s to %s.",
 
   "origins.avian_sleep_fail": "You need fresh air to sleep",
 


### PR DESCRIPTION
Since you've already handled the config and badge changes, this really only pulls in a single bugfix, changes things based on breaking Apoli changes, and reworks the `/origin` command.